### PR TITLE
Fine-grained configuration for HTTPS in dispatcher HAProxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN rm -rf /var/cache/apk/*
 
 # Adding superwhale libraries files
 RUN mkdir -p /usr/lib/superwhale
-COPY ./lib/header.cfg /usr/lib/superwhale/header.cfg
+COPY ./lib/* /usr/lib/superwhale/
 
 # Adding superwhale binary
 COPY ./bin/superwhale /bin/superwhale

--- a/README.md
+++ b/README.md
@@ -62,7 +62,30 @@ Here is an exhaustive list of what you can define for a service :
 | *options*     | `string[]`          | Options added to the backend block |
 | *is_default*  | `bool`              | If true, add `default_backend` with this backend. Only one service can define this option. |
 
-###### Gracefull reload
+
+##### Configuring `superwhale`
+
+You can tune `superwhale` configuration using the its configuration file : `/etc/superwhale.d/configs/superwhale.yml`. Here is the default version of this file :
+
+```
+# Redirect all HTTP traffic to its HTTPS counterpart
+force_ssl: false
+
+# If you want some domains/sub-domains to not be ssl forced, uncomment this
+#ssl_noforce_domain:
+# - my.domain.tld
+# - [...]
+
+# Change the log level : debug, info (default) and warning
+log_level: info
+
+# Uncomment this to add some directive to the dispatcher frontend declaration :
+#dispatcher_frontend:
+# - myoption true
+# - [...]
+```
+
+##### Gracefull reload
 
 When you modify services if we restart HAProxy on-the-fly it will interrupt all active connections, breaking current downloads, streamings etc... To avoid this, there is not one HAProxy, but three. There is one in the front named `dispatcher`, and 2 behinds : `master` and `slave`. When configuration is changed, slave is restarted, then master is. Using the capability of HAProxy to exit the process only when all connections are closed, there is no lost of connections.
 
@@ -81,20 +104,7 @@ is failing, while still doing the job during the time it needs to detect it.
 
 ##### Setting `haproxy.cfg` header
 
-By default, this `defaults` section will be added at the top of the HAProxies configuration files :
-
-```
-defaults
-  maxconn 4096
-  log global
-  mode http
-  retries 3
-  timeout connect 5s
-  timeout client 15min
-  timeout server 15min
-```
-
-You can override this simply by adding a `header.cfg` file in `/etc/superwhale.d`.
+You can modify `header.cfg` or `dispatcher_header.cfg` (depending with instance you want to tune) file in `/etc/superwhale.d`.
 
 ##### Using HTTPS
 
@@ -104,11 +114,7 @@ You can use HTTPS by simply adding certificate file : `/etc/superwhale.d/https.p
 $ cat server.crt server.key > /etc/superwhale.d/https.pem
 ```
 
-If you want to redirect all HTTP traffic to HTTPS, add a modifier to the container `run` command : `docker run [...] bahaika/whale-haproxy --force-ssl`.
-
-##### Debugging container
-
-If you want a verbose output for debugging purposes, add a modifier to the container `run` command : `docker run [...] bahaika/whale-haproxy --debug`. You can display less informations with a `--info` modifier.
+If you want to redirect all traffic to HTTPS, switch the `force_ssl` boolean to true inside the superwhale configuration file.
 
 ##### Launching the container
 

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+# Creating folders and copying default files
+if [ ! -d '/etc/superwhale.d/services' ]; then
+    mkdir -p /etc/superwhale.d/services
+fi
+if [ ! -d '/etc/superwhale.d/configs' ]; then
+    mkdir -p /etc/superwhale.d/configs
+    cp /usr/lib/superwhale/* /etc/superwhale.d/configs
+fi
+
+# Starting SuperWhale
 if [ -z "$1" ]; then
     exec /bin/superwhale
 elif [ "${1:0:1}" = '-' ]; then

--- a/bin/superwhale
+++ b/bin/superwhale
@@ -7,10 +7,7 @@ require 'logger'
 
 # Folders constants
 PATHS = {
-    superwhale: {
-        custom: '/etc/superwhale.d',
-        defaults: '/usr/lib/superwhale',
-    },
+    superwhale: '/etc/superwhale.d',
     haproxy: '/etc/haproxy',
     hosts: '/etc/hosts'
 }
@@ -18,16 +15,9 @@ PATHS = {
 # SuperWhale constants
 SUPERWHALE = {
     version: '1.0.0',
-    debug: ARGV.include?('--debug'),
-    info: ARGV.include?('--info'),
-    services: "#{PATHS[:superwhale][:custom]}/*.yml",
-    defaults: {
-        header: "#{PATHS[:superwhale][:defaults]}/header.cfg"
-    },
-    custom: {
-        header: "#{PATHS[:superwhale][:custom]}/header.cfg",
-        https_cert: "#{PATHS[:superwhale][:custom]}/https.pem"
-    },
+    config: YAML.load_file("#{PATHS[:superwhale]}/configs/superwhale.yml"),
+    services: "#{PATHS[:superwhale]}/services/*.yml",
+    https_cert: "#{PATHS[:superwhale]}/configs/https.pem",
     failed_services: []
 }
 
@@ -35,7 +25,9 @@ SUPERWHALE = {
 HAPROXY = {
     binary: '/usr/sbin/haproxy',
     debug_flag: '-d',
+    proxies_header: "#{PATHS[:superwhale]}/configs/header.cfg",
     dispatcher: {
+        header: "#{PATHS[:superwhale]}/configs/dispatcher_header.cfg",
         config: "#{PATHS[:haproxy]}/haproxy_dispatcher.cfg"
     },
     master: {
@@ -50,12 +42,15 @@ HAPROXY = {
 
 # Logging helper
 LOGGER = Logger.new(STDOUT)
-LOGGER.level = if SUPERWHALE[:debug]
-                 Logger::DEBUG
-               elsif SUPERWHALE[:info]
-                 Logger::INFO
-               else
-                 Logger::WARN
+LOGGER.level = case SUPERWHALE[:config]['log_level']
+                 when 'debug'
+                   Logger::DEBUG
+                 when 'info'
+                   Logger::INFO
+                 when 'warning'
+                   Logger::WARN
+                 else
+                   Logger::WARN
                end
 
 # Checks if a host exists in /etc/hosts file
@@ -66,13 +61,7 @@ end
 
 def compile_haproxy_config(frontend_directives, backend_blocks, instance_port)
   # Loading header of haproxy configuration file
-  haproxy_cfg = if File.exist? SUPERWHALE[:custom][:header]
-                  LOGGER.info 'Loaded custom haproxy config header'
-                  File.read SUPERWHALE[:custom][:header]
-                else
-                  LOGGER.info 'Loaded default haproxy config header'
-                  File.read SUPERWHALE[:defaults][:header]
-                end
+  haproxy_cfg = File.read HAPROXY[:proxies_header]
 
   # Compiling frontend block
   haproxy_cfg << "\n\nfrontend public\n"
@@ -91,47 +80,53 @@ def compile_haproxy_config(frontend_directives, backend_blocks, instance_port)
   haproxy_cfg
 end
 
-# Create HAProxies configuration from superwhale services
-def create_haproxy_config(generate_dispatcher)
+def create_dispatcher_config
+  # Dispatcher defaults
+  dispatcher_config = File.read HAPROXY[:dispatcher][:header]
 
-  # Generating dispatcher configuration
-  if generate_dispatcher
-    # Dispatcher defaults
-    dispatcher_config = "defaults\n"
-    dispatcher_config << "  maxconn 4096\n"
-    dispatcher_config << "  log global\n"
-    dispatcher_config << "  mode http\n"
-    dispatcher_config << "  retries 3\n"
-    dispatcher_config << "  timeout connect 5s\n"
-    dispatcher_config << "  timeout client 15m\n"
-    dispatcher_config << "  timeout server 15m\n\n"
+  # Dispatcher frontend
+  dispatcher_config << "frontend public\n"
+  dispatcher_config << "  bind *:80\n"
 
-    # Dispatcher frontend
-    dispatcher_config << "frontend public\n"
-    dispatcher_config << "  bind *:80\n"
+  # Frontend HTTPS management
+  if File.exist? SUPERWHALE[:https_cert]
+    LOGGER.info 'Certificate found, activating SSL'
+    dispatcher_config << "  bind *:443 ssl crt #{SUPERWHALE[:https_cert]}\n"
 
-    # Frontend HTTPS management
-    if File.exist? SUPERWHALE[:custom][:https_cert]
-      LOGGER.info 'Certificate found, activating SSL'
-      dispatcher_config << "  bind *:443 ssl crt #{SUPERWHALE[:custom][:https_cert]}\n"
-      if ARGV.include? '--force-ssl'
-        dispatcher_config << "  redirect scheme https if !{ ssl_fc }\n"
-      end
-    else
-      LOGGER.warn 'No certificate found, disabling SSL capabilities'
+    if SUPERWHALE[:config]['force_ssl']
+
+      LOGGER.info 'Forcing HTTPS over HTTP'
+
+      https_domain_exclusion = ''
+      SUPERWHALE[:config]['ssl_noforce_domain'].each do |domain|
+        https_domain_exclusion << "!{ hdr(host) -i #{domain} } "
+        LOGGER.info "Excluding #{domain} from HTTPS forcing"
+      end if SUPERWHALE[:config].has_key? 'ssl_noforce_domain'
+
+      dispatcher_config << "  redirect scheme https if !{ ssl_fc } #{https_domain_exclusion}\n"
     end
-    dispatcher_config << "  default_backend dispatched\n\n"
 
-    # Dispatcher backend
-    dispatcher_config << "backend dispatched\n"
-    dispatcher_config << "  server master 127.0.0.1:#{HAPROXY[:master][:port]} check\n"
-    dispatcher_config << "  server slave 127.0.0.1:#{HAPROXY[:slave][:port]} check backup\n"
 
-    LOGGER.debug "Dispatcher configuration:\n\n#{dispatcher_config}"
-
-    File.write HAPROXY[:dispatcher][:config], dispatcher_config
+    SUPERWHALE[:config]['dispatcher_frontend'].each do |directive|
+      dispatcher_config << "  #{directive}\n"
+    end if SUPERWHALE[:config].has_key? 'dispatcher_frontend'
+  else
+    LOGGER.warn 'No certificate found, disabling SSL capabilities'
   end
+  dispatcher_config << "  default_backend dispatched\n\n"
 
+  # Dispatcher backend
+  dispatcher_config << "backend dispatched\n"
+  dispatcher_config << "  server master 127.0.0.1:#{HAPROXY[:master][:port]} check\n"
+  dispatcher_config << "  server slave 127.0.0.1:#{HAPROXY[:slave][:port]} check backup\n"
+
+  LOGGER.debug "Dispatcher configuration:\n\n#{dispatcher_config}"
+
+  File.write HAPROXY[:dispatcher][:config], dispatcher_config
+end
+
+# Create HAProxies configuration from superwhale services
+def create_haproxies_config
 
   LOGGER.info 'Parsing configurations'
 
@@ -242,26 +237,28 @@ end
 
 # Entry point
 def main
-  LOGGER.warn "Starting up SuperWhale, version #{PATHS[:superwhale][:version]} !"
+  LOGGER.warn "Starting up SuperWhale, version #{SUPERWHALE[:version]} !"
 
   # Creating haproxy configuration file including dispatcher config
-  create_haproxy_config true
+  create_dispatcher_config
+  create_haproxies_config
 
   # Starting master HAProxy process...
   haproxy_master_pid = start_haproxy HAPROXY[:master][:config]
   haproxy_slave_pid = start_haproxy HAPROXY[:slave][:config]
 
+  # Wait 2 second for haproxies to start up
   sleep 2
 
   # Starting dispatcher HAProxy process...
   start_haproxy HAPROXY[:dispatcher][:config]
 
   # Watching for file changes, (blocking)
-  FileWatcher.new([PATHS[:hosts], "#{PATHS[:superwhale][:custom]}/*"]).watch do
+  FileWatcher.new([PATHS[:hosts], SUPERWHALE[:services]]).watch do
     LOGGER.warn 'File modification detected !'
 
     # Recreating haproxy configuration file without dispatcher config
-    create_haproxy_config false
+    create_haproxies_config
 
     # Killing slave
     LOGGER.info 'Killing slave'

--- a/lib/dispatcher_header.cfg
+++ b/lib/dispatcher_header.cfg
@@ -1,3 +1,6 @@
+global
+  tune.ssl.default-dh-param 2048
+
 defaults
   maxconn 4096
   log global

--- a/lib/superwhale.yml
+++ b/lib/superwhale.yml
@@ -1,0 +1,15 @@
+# Redirect all HTTP traffic to its HTTPS counterpart
+force_ssl: false
+
+# If you want some domains/sub-domains to not be ssl forced, uncomment this
+#ssl_noforce_domain:
+# - my.domain.tld
+# - [...]
+
+# Change the log level : debug, info (default) and warning
+log_level: info
+
+# Uncomment this to add some directive to the dispatcher frontend declaration :
+#dispatcher_frontend:
+# - myoption true
+# - [...]


### PR DESCRIPTION
This adds fine-grained configuration for HTTPS inside the HAProxy dispatcher. To make directories cleaner, I also added some sub-directories inside `/etc/superwhale.d/`. This update will break configuration file compatibility with v1.0.0.
